### PR TITLE
Fixed error adding Kali's GPG key

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ fi
 /usr/bin/env python3 -V >/dev/null || die "Please install 'python3'";
 
 # Install all dependencies:
-apt-key adv -qq --keyserver pool.sks-keyservers.net --recv-keys ED444FF07D8D0BF6 || apt-key adv -qq --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys ED444FF07D8D0BF6 || die "This may be a server issue. Please try again later";
+wget -q -O - https://archive.kali.org/archive-key.asc | apt-key add
 apt-get -qq -y -m install python3-apt || die;
 
 install -T -g root -o root -m 555 ./katoolin3.py "$DIR/$PROGRAM" || die;


### PR DESCRIPTION
The formerly used key ED444FF07D8D0BF6 expired and is not any more on the common key servers. The new key can be fetched directly from [https://archive.kali.org/archive-key.asc](https://archive.kali.org/archive-key.asc). This resolves [issue #22](https://github.com/s-h-3-l-l/katoolin3/issues/22).
You can additionally refer to [this news blog from Kali](https://www.kali.org/news/kali-linux-2018-1-release/) under sub-headline "Package Updates".